### PR TITLE
Implement dashboard data hooks

### DIFF
--- a/apps/client/src/hooks/useDashboardData.ts
+++ b/apps/client/src/hooks/useDashboardData.ts
@@ -1,0 +1,82 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { User, Class, Resource, Event, Child, Schedule } from '@/types';
+
+export const useAdminStats = () => {
+  const usersQuery = useQuery({
+    queryKey: ['admin', 'users'],
+    queryFn: async (): Promise<{ users: User[] }> => apiClient.get('/users'),
+  });
+
+  const classesQuery = useQuery({
+    queryKey: ['admin', 'classes'],
+    queryFn: async (): Promise<{ classes: Class[] }> => apiClient.get('/classes'),
+  });
+
+  const pendingResourcesQuery = useQuery({
+    queryKey: ['admin', 'pending-resources'],
+    queryFn: async (): Promise<{ resources: Resource[] }> => apiClient.get('/resources/pending'),
+  });
+
+  const eventsQuery = useQuery({
+    queryKey: ['admin', 'events'],
+    queryFn: async (): Promise<{ events: Event[] }> => apiClient.get('/events'),
+  });
+
+  return {
+    users: usersQuery.data?.users ?? [],
+    classes: classesQuery.data?.classes ?? [],
+    pendingResources: pendingResourcesQuery.data?.resources ?? [],
+    events: eventsQuery.data?.events ?? [],
+    isLoading:
+      usersQuery.isLoading ||
+      classesQuery.isLoading ||
+      pendingResourcesQuery.isLoading ||
+      eventsQuery.isLoading,
+  };
+};
+
+export const useParentDashboard = () => {
+  const childrenQuery = useQuery({
+    queryKey: ['parent', 'children'],
+    queryFn: async (): Promise<{ children: Child[] }> =>
+      apiClient.get('/children/my-children'),
+  });
+
+  const eventsQuery = useQuery({
+    queryKey: ['parent', 'events'],
+    queryFn: async (): Promise<{ events: Event[] }> => apiClient.get('/events'),
+  });
+
+  return {
+    children: childrenQuery.data?.children ?? [],
+    events: eventsQuery.data?.events ?? [],
+    isLoading: childrenQuery.isLoading || eventsQuery.isLoading,
+  };
+};
+
+export const useTeacherDashboard = () => {
+  const schedulesQuery = useQuery({
+    queryKey: ['teacher', 'schedules'],
+    queryFn: async (): Promise<{ schedules: Schedule[] }> =>
+      apiClient.get('/schedules/teacher/me'),
+  });
+
+  const eventsQuery = useQuery({
+    queryKey: ['teacher', 'events'],
+    queryFn: async (): Promise<{ events: Event[] }> => apiClient.get('/events'),
+  });
+
+  const resourcesQuery = useQuery({
+    queryKey: ['teacher', 'resources'],
+    queryFn: async (): Promise<{ resources: Resource[] }> => apiClient.get('/resources'),
+  });
+
+  return {
+    schedules: schedulesQuery.data?.schedules ?? [],
+    events: eventsQuery.data?.events ?? [],
+    resources: resourcesQuery.data?.resources ?? [],
+    isLoading:
+      schedulesQuery.isLoading || eventsQuery.isLoading || resourcesQuery.isLoading,
+  };
+};

--- a/apps/client/src/pages/admin/AdminDashboard.tsx
+++ b/apps/client/src/pages/admin/AdminDashboard.tsx
@@ -1,57 +1,45 @@
 import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { useAdminStats } from '@/hooks/useDashboardData';
+
+const StatCard: React.FC<{ title: string; value: number | string }> = ({ title, value }) => (
+  <Card>
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p className="text-4xl font-bold">{value}</p>
+    </CardContent>
+  </Card>
+);
 
 const AdminDashboard: React.FC = () => {
+  const { users, classes, pendingResources, events, isLoading } = useAdminStats();
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold">Admin Dashboard</h1>
-      
+
+      {isLoading && <p>Loading stats...</p>}
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Total Users</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-4xl font-bold">120</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Active Classes</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-4xl font-bold">15</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Pending Resources</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-4xl font-bold">3</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Upcoming Events</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-4xl font-bold">7</p>
-          </CardContent>
-        </Card>
+        <StatCard title="Total Users" value={users.length} />
+        <StatCard title="Active Classes" value={classes.length} />
+        <StatCard title="Pending Resources" value={pendingResources.length} />
+        <StatCard title="Upcoming Events" value={events.length} />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>Recent Activity Feed</CardTitle>
+            <CardTitle>Upcoming Events</CardTitle>
           </CardHeader>
           <CardContent>
-            {/* Placeholder for activity feed */}
             <ul className="space-y-2">
-              <li>New user registered: John Doe</li>
-              <li>Resource uploaded: "Lesson Plan - Genesis"</li>
-              <li>Class updated: "Ages 6-8" capacity changed</li>
+              {events.slice(0, 5).map((event) => (
+                <li key={event._id}>{event.title}</li>
+              ))}
+              {events.length === 0 && <li className="text-sm text-gray-500">No upcoming events</li>}
             </ul>
           </CardContent>
         </Card>

--- a/apps/client/src/pages/parent/ParentDashboard.tsx
+++ b/apps/client/src/pages/parent/ParentDashboard.tsx
@@ -3,48 +3,20 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Baby, Calendar, BookOpen, Camera } from 'lucide-react';
 import { calculateAge } from '@/lib/utils';
+import { useParentDashboard } from '@/hooks/useDashboardData';
 
 const ParentDashboard: React.FC = () => {
-  // Mock data - in real app, this would come from API
-  const children = [
-    {
-      id: '1',
-      firstName: 'Emma',
-      lastName: 'Johnson',
-      dateOfBirth: '2015-06-15',
-      assignedClass: 'Ages 6-8'
-    },
-    {
-      id: '2',
-      firstName: 'Liam',
-      lastName: 'Johnson',
-      dateOfBirth: '2018-03-22',
-      assignedClass: 'Ages 3-5'
-    }
-  ];
-
-  const upcomingEvents = [
-    {
-      id: '1',
-      title: 'Easter Celebration',
-      type: 'Event',
-      date: '2024-04-09'
-    },
-    {
-      id: '2',
-      title: 'Memory Verse Challenge',
-      type: 'Memory Verse',
-      date: '2024-03-20'
-    }
-  ];
+  const { children, events, isLoading } = useParentDashboard();
 
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold">Parent Dashboard</h1>
+
+      {isLoading && <p>Loading...</p>}
       
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {children.map((child) => (
-          <Card key={child.id}>
+          <Card key={child._id}>
             <CardHeader>
               <CardTitle className="flex items-center">
                 <Baby className="mr-2 h-5 w-5" />
@@ -55,7 +27,7 @@ const ParentDashboard: React.FC = () => {
               <div className="space-y-2">
                 <p><span className="font-medium">Age:</span> {calculateAge(child.dateOfBirth)} years old</p>
                 <p><span className="font-medium">Class:</span> {child.assignedClass}</p>
-                <p><span className="font-medium">Last Attendance:</span> Present (March 5)</p>
+                <p><span className="font-medium">Last Attendance:</span> N/A</p>
               </div>
               <Button className="w-full mt-4" variant="outline">
                 View Details
@@ -75,13 +47,16 @@ const ParentDashboard: React.FC = () => {
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
-              {upcomingEvents.map((event) => (
-                <div key={event.id} className="border-l-4 border-primary pl-3">
+              {events.map((event) => (
+                <div key={event._id} className="border-l-4 border-primary pl-3">
                   <p className="font-medium">{event.title}</p>
                   <p className="text-sm text-gray-600">{event.type}</p>
                   <p className="text-sm text-gray-500">{new Date(event.date).toLocaleDateString()}</p>
                 </div>
               ))}
+              {events.length === 0 && (
+                <p className="text-sm text-gray-500">No upcoming events</p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/apps/client/src/pages/teacher/TeacherDashboard.tsx
+++ b/apps/client/src/pages/teacher/TeacherDashboard.tsx
@@ -2,15 +2,23 @@ import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Calendar, Users, FileText } from 'lucide-react';
+import { formatDate, formatTime } from '@/lib/utils';
+import { useTeacherDashboard } from '@/hooks/useDashboardData';
 
 const TeacherDashboard: React.FC = () => {
+  const { schedules, events, resources, isLoading } = useTeacherDashboard();
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold">Teacher Dashboard</h1>
+
+      {isLoading && <p>Loading...</p>}
       
       <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
         <h2 className="text-lg font-semibold text-blue-800">New Announcement</h2>
-        <p className="text-blue-700">Don't forget about the upcoming Easter celebration on April 9th!</p>
+        <p className="text-blue-700">
+          {events[0] ? events[0].title : 'No announcements available'}
+        </p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -23,16 +31,20 @@ const TeacherDashboard: React.FC = () => {
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
-              <div className="border-l-4 border-blue-500 pl-3">
-                <p className="font-medium">Ages 6-8</p>
-                <p className="text-sm text-gray-600">Sunday, March 12 - 10:00 AM</p>
-                <p className="text-sm text-gray-500">15 students</p>
-              </div>
-              <div className="border-l-4 border-green-500 pl-3">
-                <p className="font-medium">Ages 9-11</p>
-                <p className="text-sm text-gray-600">Sunday, March 19 - 11:00 AM</p>
-                <p className="text-sm text-gray-500">12 students</p>
-              </div>
+              {schedules.map((schedule) => (
+                <div key={schedule._id} className="border-l-4 border-blue-500 pl-3">
+                  <p className="font-medium">{(schedule.class as any).name}</p>
+                  <p className="text-sm text-gray-600">
+                    {formatDate(schedule.date)} - {formatTime(schedule.date)}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    {(schedule.students as any[]).length} students
+                  </p>
+                </div>
+              ))}
+              {schedules.length === 0 && (
+                <p className="text-sm text-gray-500">No upcoming classes</p>
+              )}
             </div>
             <Button className="w-full mt-4" variant="outline">
               View All Classes
@@ -69,18 +81,15 @@ const TeacherDashboard: React.FC = () => {
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
-              <div className="text-sm">
-                <p className="font-medium">Noah's Ark Craft</p>
-                <p className="text-gray-600">Approved</p>
-              </div>
-              <div className="text-sm">
-                <p className="font-medium">Memory Verse Song</p>
-                <p className="text-yellow-600">Pending</p>
-              </div>
-              <div className="text-sm">
-                <p className="font-medium">Easter Lesson Plan</p>
-                <p className="text-gray-600">Approved</p>
-              </div>
+              {resources.slice(0, 3).map((res) => (
+                <div key={res._id} className="text-sm">
+                  <p className="font-medium">{res.title}</p>
+                  <p className={res.status === 'Pending' ? 'text-yellow-600' : 'text-gray-600'}>{res.status}</p>
+                </div>
+              ))}
+              {resources.length === 0 && (
+                <p className="text-sm text-gray-500">No resources uploaded</p>
+              )}
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- add data fetching hooks for dashboards
- integrate admin, parent and teacher dashboards with backend
- display new event announcement dynamically

## Testing
- `pnpm lint` *(fails: couldn't find eslint config)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687c8aa2ea3083279dd5cdd46d148ef7