### PR TITLE
Implement admin management pages

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -7,6 +7,12 @@ import Layout from '@/components/layout/Layout';
 import Login from '@/pages/Login';
 import Register from '@/pages/Register';
 import Dashboard from '@/pages/Dashboard';
+import UserManagement from '@/pages/admin/UserManagement';
+import ClassManagement from '@/pages/admin/ClassManagement';
+import Scheduling from '@/pages/admin/Scheduling';
+import ResourceModeration from '@/pages/admin/ResourceModeration';
+import GalleryModeration from '@/pages/admin/GalleryModeration';
+import AdminSettings from '@/pages/admin/AdminSettings';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -51,12 +57,12 @@ const AppRoutes: React.FC = () => {
         >
           <Route path="dashboard" element={<Dashboard />} />
           {/* Admin routes */}
-          <Route path="admin/users" element={<div>User Management (Coming Soon)</div>} />
-          <Route path="admin/classes" element={<div>Class Management (Coming Soon)</div>} />
-          <Route path="admin/schedules" element={<div>Scheduling (Coming Soon)</div>} />
-          <Route path="admin/resources" element={<div>Resource Moderation (Coming Soon)</div>} />
-          <Route path="admin/gallery" element={<div>Gallery Moderation (Coming Soon)</div>} />
-          <Route path="admin/settings" element={<div>Settings (Coming Soon)</div>} />
+          <Route path="admin/users" element={<UserManagement />} />
+          <Route path="admin/classes" element={<ClassManagement />} />
+          <Route path="admin/schedules" element={<Scheduling />} />
+          <Route path="admin/resources" element={<ResourceModeration />} />
+          <Route path="admin/gallery" element={<GalleryModeration />} />
+          <Route path="admin/settings" element={<AdminSettings />} />
           
           {/* Teacher routes */}
           <Route path="teacher/classes" element={<div>My Classes (Coming Soon)</div>} />

--- a/apps/client/src/pages/admin/AdminSettings.tsx
+++ b/apps/client/src/pages/admin/AdminSettings.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AdminSettings: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Settings</h1>
+      <p>Settings management will be added soon.</p>
+    </div>
+  );
+};
+
+export default AdminSettings;

--- a/apps/client/src/pages/admin/ClassManagement.tsx
+++ b/apps/client/src/pages/admin/ClassManagement.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Class } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const ClassManagement: React.FC = () => {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(['classes'], async () =>
+    apiClient.get<{ classes: Class[] }>('/classes')
+  );
+
+  const deleteClassMutation = useMutation(
+    async (id: string) => apiClient.delete(`/classes/${id}`),
+    {
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['classes'] }),
+    }
+  );
+
+  if (isLoading) {
+    return <div>Loading classes...</div>;
+  }
+
+  const classes = data?.classes ?? [];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Class Management</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>All Classes</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Name
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Age Range
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Capacity
+                </th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {classes.map((cls) => (
+                <tr key={cls._id}>
+                  <td className="px-4 py-2">{cls.name}</td>
+                  <td className="px-4 py-2">{cls.ageRange}</td>
+                  <td className="px-4 py-2">{cls.capacity}</td>
+                  <td className="px-4 py-2 text-right">
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => deleteClassMutation.mutate(cls._id)}
+                    >
+                      Delete
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {classes.length === 0 && (
+                <tr>
+                  <td className="px-4 py-2" colSpan={4}>
+                    No classes found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ClassManagement;

--- a/apps/client/src/pages/admin/GalleryModeration.tsx
+++ b/apps/client/src/pages/admin/GalleryModeration.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { GalleryImage } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const GalleryModeration: React.FC = () => {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(['pending-images'], async () =>
+    apiClient.get<{ images: GalleryImage[] }>('/gallery/pending')
+  );
+
+  const updateStatusMutation = useMutation(
+    async ({ id, status }: { id: string; status: 'Approved' | 'Rejected' }) =>
+      apiClient.put(`/gallery/${id}/status`, { status }),
+    {
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['pending-images'] }),
+    }
+  );
+
+  if (isLoading) {
+    return <div>Loading images...</div>;
+  }
+
+  const images = data?.images ?? [];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Gallery Moderation</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Pending Images</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {images.map((img) => (
+            <div key={img._id} className="flex items-center justify-between border p-3 rounded-md">
+              <div className="flex items-center space-x-3">
+                <img src={img.imageUrl} alt={img.caption || 'image'} className="h-16 w-16 object-cover rounded-md" />
+                <div>
+                  <p className="font-medium">{img.caption || 'No caption'}</p>
+                </div>
+              </div>
+              <div className="space-x-2">
+                <Button size="sm" onClick={() => updateStatusMutation.mutate({ id: img._id, status: 'Approved' })}>
+                  Approve
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => updateStatusMutation.mutate({ id: img._id, status: 'Rejected' })}>
+                  Reject
+                </Button>
+              </div>
+            </div>
+          ))}
+          {images.length === 0 && <p className="text-sm text-gray-500">No pending images.</p>}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default GalleryModeration;

--- a/apps/client/src/pages/admin/ResourceModeration.tsx
+++ b/apps/client/src/pages/admin/ResourceModeration.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Resource } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const ResourceModeration: React.FC = () => {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(['pending-resources'], async () =>
+    apiClient.get<{ resources: Resource[] }>('/resources/pending')
+  );
+
+  const updateStatusMutation = useMutation(
+    async ({ id, status }: { id: string; status: 'Approved' | 'Rejected' }) =>
+      apiClient.put(`/resources/${id}/status`, { status }),
+    {
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: ['pending-resources'] }),
+    }
+  );
+
+  if (isLoading) {
+    return <div>Loading resources...</div>;
+  }
+
+  const resources = data?.resources ?? [];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Resource Moderation</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Pending Resources</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {resources.map((resource) => (
+            <div
+              key={resource._id}
+              className="flex items-center justify-between border p-3 rounded-md"
+            >
+              <div>
+                <p className="font-medium">{resource.title}</p>
+                <p className="text-sm text-gray-600">{resource.type}</p>
+              </div>
+              <div className="space-x-2">
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    updateStatusMutation.mutate({
+                      id: resource._id,
+                      status: 'Approved',
+                    })
+                  }
+                >
+                  Approve
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() =>
+                    updateStatusMutation.mutate({
+                      id: resource._id,
+                      status: 'Rejected',
+                    })
+                  }
+                >
+                  Reject
+                </Button>
+              </div>
+            </div>
+          ))}
+          {resources.length === 0 && (
+            <p className="text-sm text-gray-500">No pending resources.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ResourceModeration;

--- a/apps/client/src/pages/admin/Scheduling.tsx
+++ b/apps/client/src/pages/admin/Scheduling.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Schedule } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const Scheduling: React.FC = () => {
+  const { data, isLoading } = useQuery(['schedules'], async () =>
+    apiClient.get<{ schedules: Schedule[] }>('/schedules')
+  );
+
+  if (isLoading) {
+    return <div>Loading schedules...</div>;
+  }
+
+  const schedules = data?.schedules ?? [];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Scheduling</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Upcoming Schedules</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Class
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Teacher
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Date
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {schedules.map((schedule) => (
+                <tr key={schedule._id}>
+                  <td className="px-4 py-2">{(schedule.class as any).name}</td>
+                  <td className="px-4 py-2">{(schedule.teacher as any).name}</td>
+                  <td className="px-4 py-2">
+                    {new Date(schedule.date).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+              {schedules.length === 0 && (
+                <tr>
+                  <td className="px-4 py-2" colSpan={3}>
+                    No schedules found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Scheduling;

--- a/apps/client/src/pages/admin/UserManagement.tsx
+++ b/apps/client/src/pages/admin/UserManagement.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { User } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const UserManagement: React.FC = () => {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(['users'], async () =>
+    apiClient.get<{ users: User[] }>('/users')
+  );
+
+  const updateRoleMutation = useMutation(
+    async ({ id, role }: { id: string; role: User['role'] }) =>
+      apiClient.put(`/users/${id}/role`, { role }),
+    {
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
+    }
+  );
+
+  const deleteUserMutation = useMutation(
+    async (id: string) => apiClient.delete(`/users/${id}`),
+    {
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
+    }
+  );
+
+  if (isLoading) {
+    return <div>Loading users...</div>;
+  }
+
+  const users = data?.users ?? [];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">User Management</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>All Users</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Name
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Email
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                  Role
+                </th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {users.map((user) => (
+                <tr key={user.id}>
+                  <td className="px-4 py-2">{user.name}</td>
+                  <td className="px-4 py-2">{user.email}</td>
+                  <td className="px-4 py-2">
+                    <select
+                      className="border rounded-md px-2 py-1"
+                      value={user.role}
+                      onChange={(e) =>
+                        updateRoleMutation.mutate({
+                          id: user.id,
+                          role: e.target.value as User['role'],
+                        })
+                      }
+                    >
+                      <option value="Admin">Admin</option>
+                      <option value="Teacher">Teacher</option>
+                      <option value="Parent">Parent</option>
+                    </select>
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => deleteUserMutation.mutate(user.id)}
+                    >
+                      Delete
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {users.length === 0 && (
+                <tr>
+                  <td className="px-4 py-2" colSpan={4}>
+                    No users found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default UserManagement;


### PR DESCRIPTION
## Summary
- implement user management, class management, scheduling, resource moderation, and gallery moderation pages
- wire up settings placeholder page
- update router to use new admin pages

## Testing
- `npm test` *(fails: no test specified)*
- `pnpm --filter client lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c8cf7dbd483279f57d1ce7604c9bd