### PR TITLE
Add resource and gallery pages

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -13,6 +13,14 @@ import Scheduling from '@/pages/admin/Scheduling';
 import ResourceModeration from '@/pages/admin/ResourceModeration';
 import GalleryModeration from '@/pages/admin/GalleryModeration';
 import AdminSettings from '@/pages/admin/AdminSettings';
+import Gallery from '@/pages/Gallery';
+import ResourceLibrary from '@/pages/ResourceLibrary';
+import TeacherResources from '@/pages/teacher/TeacherResources';
+import GalleryUpload from '@/pages/teacher/GalleryUpload';
+import TeacherClasses from '@/pages/teacher/TeacherClasses';
+import Children from '@/pages/parent/Children';
+import ParentResources from '@/pages/parent/ParentResources';
+import ParentGallery from '@/pages/parent/ParentGallery';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -63,18 +71,22 @@ const AppRoutes: React.FC = () => {
           <Route path="admin/resources" element={<ResourceModeration />} />
           <Route path="admin/gallery" element={<GalleryModeration />} />
           <Route path="admin/settings" element={<AdminSettings />} />
-          
+
           {/* Teacher routes */}
-          <Route path="teacher/classes" element={<div>My Classes (Coming Soon)</div>} />
+          <Route path="teacher/classes" element={<TeacherClasses />} />
           <Route path="teacher/attendance" element={<div>Attendance (Coming Soon)</div>} />
-          <Route path="teacher/resources" element={<div>Resources (Coming Soon)</div>} />
-          <Route path="teacher/gallery" element={<div>Gallery Upload (Coming Soon)</div>} />
-          
+          <Route path="teacher/resources" element={<TeacherResources />} />
+          <Route path="teacher/gallery" element={<GalleryUpload />} />
+
           {/* Parent routes */}
-          <Route path="parent/children" element={<div>My Children (Coming Soon)</div>} />
+          <Route path="parent/children" element={<Children />} />
           <Route path="parent/attendance" element={<div>Attendance (Coming Soon)</div>} />
-          <Route path="parent/resources" element={<div>Resources (Coming Soon)</div>} />
-          <Route path="parent/gallery" element={<div>Gallery (Coming Soon)</div>} />
+          <Route path="parent/resources" element={<ParentResources />} />
+          <Route path="parent/gallery" element={<ParentGallery />} />
+
+          {/* Shared pages */}
+          <Route path="resources" element={<ResourceLibrary />} />
+          <Route path="gallery" element={<Gallery />} />
           
           <Route path="" element={<Navigate to="/dashboard" replace />} />
         </Route>

--- a/apps/client/src/components/layout/Sidebar.tsx
+++ b/apps/client/src/components/layout/Sidebar.tsx
@@ -27,6 +27,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   const getNavigationItems = () => {
     const baseItems = [
       { name: 'Dashboard', href: '/dashboard', icon: Home },
+      { name: 'Resources', href: '/resources', icon: FileText },
+      { name: 'Gallery', href: '/gallery', icon: Camera },
     ];
 
     if (user?.role === 'Admin') {

--- a/apps/client/src/hooks/useChildren.ts
+++ b/apps/client/src/hooks/useChildren.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Child } from '@/types';
+
+export const useMyChildren = () => {
+  const query = useQuery({
+    queryKey: ['parent', 'children'],
+    queryFn: async (): Promise<{ children: Child[] }> =>
+      apiClient.get('/children/my-children'),
+  });
+
+  return {
+    children: query.data?.children ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+};

--- a/apps/client/src/hooks/useGallery.ts
+++ b/apps/client/src/hooks/useGallery.ts
@@ -1,0 +1,25 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { GalleryImage } from '@/types';
+
+export const useGalleryImages = () => {
+  const query = useQuery({
+    queryKey: ['gallery', 'images'],
+    queryFn: async (): Promise<{ images: GalleryImage[] }> => apiClient.get('/gallery'),
+  });
+
+  return {
+    images: query.data?.images ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+};
+
+export const useUploadGalleryImage = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (formData: FormData) =>
+      apiClient.uploadFile('/gallery/upload', formData),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['gallery', 'images'] }),
+  });
+};

--- a/apps/client/src/hooks/useResources.ts
+++ b/apps/client/src/hooks/useResources.ts
@@ -1,0 +1,32 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Resource } from '@/types';
+
+export const useResources = (filters?: { type?: string; classId?: string }) => {
+  const query = useQuery({
+    queryKey: ['resources', filters],
+    queryFn: async (): Promise<{ resources: Resource[] }> => {
+      const params = new URLSearchParams();
+      if (filters?.type) params.append('type', filters.type);
+      if (filters?.classId) params.append('classId', filters.classId);
+      const queryString = params.toString();
+      const endpoint = queryString ? `/resources?${queryString}` : '/resources';
+      return apiClient.get(endpoint);
+    },
+  });
+
+  return {
+    resources: query.data?.resources ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+};
+
+export const useUploadResource = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (formData: FormData) =>
+      apiClient.uploadFile('/resources/upload', formData),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['resources'] }),
+  });
+};

--- a/apps/client/src/hooks/useSchedules.ts
+++ b/apps/client/src/hooks/useSchedules.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Schedule } from '@/types';
+
+export const useTeacherSchedules = () => {
+  const query = useQuery({
+    queryKey: ['teacher', 'schedules'],
+    queryFn: async (): Promise<{ schedules: Schedule[] }> =>
+      apiClient.get('/schedules/teacher/me'),
+  });
+
+  return {
+    schedules: query.data?.schedules ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+};

--- a/apps/client/src/pages/Gallery.tsx
+++ b/apps/client/src/pages/Gallery.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useGalleryImages } from '@/hooks/useGallery';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const Gallery: React.FC = () => {
+  const { images, isLoading } = useGalleryImages();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Gallery</h1>
+      {isLoading && <p>Loading images...</p>}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {images.map((img) => (
+          <Card key={img._id} className="overflow-hidden">
+            <CardHeader>
+              <CardTitle className="text-sm font-medium">{img.caption || 'Image'}</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <img src={img.imageUrl} alt={img.caption || 'image'} className="w-full h-48 object-cover" />
+            </CardContent>
+          </Card>
+        ))}
+        {images.length === 0 && !isLoading && (
+          <p className="text-sm text-gray-500">No images available.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Gallery;

--- a/apps/client/src/pages/ResourceLibrary.tsx
+++ b/apps/client/src/pages/ResourceLibrary.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useResources } from '@/hooks/useResources';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const ResourceLibrary: React.FC = () => {
+  const [typeFilter, setTypeFilter] = useState('');
+  const { resources, isLoading } = useResources({ type: typeFilter || undefined });
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Resources</h1>
+
+      <div className="flex items-center space-x-2">
+        <Label htmlFor="type">Filter by type</Label>
+        <select
+          id="type"
+          className="border rounded-md px-2 py-1"
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+        >
+          <option value="">All</option>
+          <option value="Lesson Plan">Lesson Plan</option>
+          <option value="Song">Song</option>
+          <option value="Video">Video</option>
+          <option value="Craft">Craft</option>
+        </select>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Available Resources</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {isLoading && <p>Loading resources...</p>}
+          {resources.map((res) => (
+            <div key={res._id} className="border p-2 rounded-md">
+              <p className="font-medium">{res.title}</p>
+              <p className="text-sm text-gray-600">{res.type}</p>
+              <a
+                href={res.fileUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary text-sm"
+              >
+                Download
+              </a>
+            </div>
+          ))}
+          {resources.length === 0 && !isLoading && (
+            <p className="text-sm text-gray-500">No resources found.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ResourceLibrary;

--- a/apps/client/src/pages/parent/Children.tsx
+++ b/apps/client/src/pages/parent/Children.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useMyChildren } from '@/hooks/useChildren';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { calculateAge } from '@/lib/utils';
+
+const Children: React.FC = () => {
+  const { children, isLoading } = useMyChildren();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">My Children</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {isLoading && <p>Loading children...</p>}
+        {children.map((child) => (
+          <Card key={child._id}>
+            <CardHeader>
+              <CardTitle>
+                {child.firstName} {child.lastName}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm">Age: {calculateAge(child.dateOfBirth)} years</p>
+              <p className="text-sm">Class: {child.assignedClass || 'N/A'}</p>
+            </CardContent>
+          </Card>
+        ))}
+        {children.length === 0 && !isLoading && (
+          <p className="text-sm text-gray-500">No children found.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Children;

--- a/apps/client/src/pages/parent/ParentGallery.tsx
+++ b/apps/client/src/pages/parent/ParentGallery.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Gallery from '@/pages/Gallery';
+
+const ParentGallery: React.FC = () => {
+  return <Gallery />;
+};
+
+export default ParentGallery;

--- a/apps/client/src/pages/parent/ParentResources.tsx
+++ b/apps/client/src/pages/parent/ParentResources.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ResourceLibrary from '@/pages/ResourceLibrary';
+
+const ParentResources: React.FC = () => {
+  return <ResourceLibrary />;
+};
+
+export default ParentResources;

--- a/apps/client/src/pages/teacher/GalleryUpload.tsx
+++ b/apps/client/src/pages/teacher/GalleryUpload.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useUploadGalleryImage } from '@/hooks/useGallery';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const GalleryUpload: React.FC = () => {
+  const uploadMutation = useUploadGalleryImage();
+  const [caption, setCaption] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('image', file);
+    formData.append('caption', caption);
+    uploadMutation.mutate(formData);
+    setCaption('');
+    setFile(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Upload Gallery Image</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>New Image</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div>
+              <Label htmlFor="caption">Caption</Label>
+              <Input id="caption" value={caption} onChange={(e) => setCaption(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="image">Image</Label>
+              <Input id="image" type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+            </div>
+            {uploadMutation.error && (
+              <p className="text-sm text-red-600">{(uploadMutation.error as Error).message}</p>
+            )}
+            <Button type="submit" disabled={uploadMutation.isPending}>
+              {uploadMutation.isPending ? 'Uploading...' : 'Upload'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default GalleryUpload;

--- a/apps/client/src/pages/teacher/TeacherClasses.tsx
+++ b/apps/client/src/pages/teacher/TeacherClasses.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useTeacherSchedules } from '@/hooks/useSchedules';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatDate, formatTime } from '@/lib/utils';
+
+const TeacherClasses: React.FC = () => {
+  const { schedules, isLoading } = useTeacherSchedules();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">My Classes</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Upcoming Classes</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {isLoading && <p>Loading schedules...</p>}
+          {schedules.map((sch) => (
+            <div key={sch._id} className="border p-2 rounded-md">
+              <p className="font-medium">{(sch.class as any).name}</p>
+              <p className="text-sm text-gray-600">
+                {formatDate(sch.date)} - {formatTime(sch.date)}
+              </p>
+            </div>
+          ))}
+          {schedules.length === 0 && !isLoading && (
+            <p className="text-sm text-gray-500">No upcoming classes</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default TeacherClasses;

--- a/apps/client/src/pages/teacher/TeacherResources.tsx
+++ b/apps/client/src/pages/teacher/TeacherResources.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { useResources, useUploadResource } from '@/hooks/useResources';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const TeacherResources: React.FC = () => {
+  const { resources, isLoading } = useResources();
+  const uploadMutation = useUploadResource();
+  const [title, setTitle] = useState('');
+  const [type, setType] = useState('Lesson Plan');
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('title', title);
+    formData.append('type', type);
+    uploadMutation.mutate(formData);
+    setTitle('');
+    setFile(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Resources</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Upload Resource</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div>
+              <Label htmlFor="title">Title</Label>
+              <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="type">Type</Label>
+              <select
+                id="type"
+                className="border rounded-md px-2 py-1"
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+              >
+                <option value="Lesson Plan">Lesson Plan</option>
+                <option value="Song">Song</option>
+                <option value="Video">Video</option>
+                <option value="Craft">Craft</option>
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="file">File</Label>
+              <Input id="file" type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+            </div>
+            {uploadMutation.error && (
+              <p className="text-sm text-red-600">{(uploadMutation.error as Error).message}</p>
+            )}
+            <Button type="submit" disabled={uploadMutation.isPending}>
+              {uploadMutation.isPending ? 'Uploading...' : 'Upload'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>My Resources</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {isLoading && <p>Loading resources...</p>}
+          {resources.map((res) => (
+            <div key={res._id} className="border p-2 rounded-md">
+              <p className="font-medium">{res.title}</p>
+              <p className="text-sm text-gray-600">{res.type} - {res.status}</p>
+            </div>
+          ))}
+          {resources.length === 0 && !isLoading && (
+            <p className="text-sm text-gray-500">No resources uploaded.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default TeacherResources;


### PR DESCRIPTION
## Summary
- add hooks to fetch resources, gallery images, children and schedules
- implement gallery and resource library pages
- implement teacher resource management and gallery upload pages
- implement teacher classes and parent pages
- update routes and sidebar navigation

## Testing
- `npx pnpm -r run build` *(fails: TS6310 from tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_687e81bd88308327826f60ebb4009b5a