### PR TITLE
Add site settings management

### DIFF
--- a/apps/client/src/hooks/useSettings.ts
+++ b/apps/client/src/hooks/useSettings.ts
@@ -1,0 +1,27 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Settings } from '@/types';
+
+export const useSettings = () => {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ['settings'],
+    queryFn: async (): Promise<{ settings: Settings }> => apiClient.get('/settings'),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: Partial<Settings>) => apiClient.put('/settings', data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+    },
+  });
+
+  return {
+    settings: query.data?.settings,
+    isLoading: query.isLoading,
+    error: query.error,
+    updateSettings: updateMutation.mutateAsync,
+    isUpdating: updateMutation.isPending,
+  };
+};

--- a/apps/client/src/pages/admin/AdminSettings.tsx
+++ b/apps/client/src/pages/admin/AdminSettings.tsx
@@ -1,10 +1,108 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useSettings } from '@/hooks/useSettings';
+
+interface SettingsForm {
+  siteName: string;
+  siteDescription?: string;
+  defaultUserRole: 'Admin' | 'Teacher' | 'Parent';
+}
 
 const AdminSettings: React.FC = () => {
+  const { settings, isLoading, updateSettings, isUpdating } = useSettings();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<SettingsForm>();
+
+  const defaultRole = watch('defaultUserRole');
+
+  useEffect(() => {
+    if (settings) {
+      setValue('siteName', settings.siteName);
+      setValue('siteDescription', settings.siteDescription || '');
+      setValue('defaultUserRole', settings.defaultUserRole);
+    }
+  }, [settings, setValue]);
+
+  const onSubmit = async (data: SettingsForm) => {
+    try {
+      await updateSettings(data);
+      toast.success('Settings saved');
+    } catch (error) {
+      console.error('Failed to save settings:', error);
+      toast.error('Failed to save settings');
+    }
+  };
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold">Settings</h1>
-      <p>Settings management will be added soon.</p>
+      {isLoading ? (
+        <p>Loading settings...</p>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-xl">
+          <div>
+            <label htmlFor="siteName" className="block text-sm font-medium text-gray-700 mb-1">
+              Site Name
+            </label>
+            <Input
+              id="siteName"
+              {...register('siteName', { required: 'Site name is required' })}
+            />
+            {errors.siteName && (
+              <p className="text-sm text-red-600 mt-1">{errors.siteName.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="siteDescription" className="block text-sm font-medium text-gray-700 mb-1">
+              Site Description
+            </label>
+            <Textarea id="siteDescription" {...register('siteDescription')} rows={3} />
+          </div>
+
+          <div>
+            <label htmlFor="defaultUserRole" className="block text-sm font-medium text-gray-700 mb-1">
+              Default User Role
+            </label>
+            <Select
+              defaultValue={defaultRole}
+              onValueChange={(value) => setValue('defaultUserRole', value as SettingsForm['defaultUserRole'])}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select role" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Parent">Parent</SelectItem>
+                <SelectItem value="Teacher">Teacher</SelectItem>
+                <SelectItem value="Admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+            {errors.defaultUserRole && (
+              <p className="text-sm text-red-600 mt-1">{errors.defaultUserRole.message}</p>
+            )}
+          </div>
+
+          <Button type="submit" disabled={isUpdating}>
+            {isUpdating ? 'Saving...' : 'Save Settings'}
+          </Button>
+        </form>
+      )}
     </div>
   );
 };

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -113,3 +113,12 @@ export interface ApiResponse<T = any> {
   error?: string;
 }
 
+export interface Settings {
+  _id: string;
+  siteName: string;
+  siteDescription?: string;
+  defaultUserRole: 'Admin' | 'Teacher' | 'Parent';
+  createdAt: string;
+  updatedAt: string;
+}
+

--- a/apps/server/src/controllers/settingsController.ts
+++ b/apps/server/src/controllers/settingsController.ts
@@ -1,0 +1,27 @@
+import { Response } from 'express';
+import Settings from '../models/settings.model';
+import { AuthRequest } from '../middleware/authMiddleware';
+
+export const getSettings = async (req: AuthRequest, res: Response) => {
+  try {
+    const settings = await Settings.findOne();
+    res.json({ settings });
+  } catch (error) {
+    console.error('Get settings error:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const updateSettings = async (req: AuthRequest, res: Response) => {
+  try {
+    const updates = req.body;
+    const settings = await Settings.findOneAndUpdate({}, updates, {
+      new: true,
+      upsert: true,
+    });
+    res.json({ message: 'Settings updated successfully', settings });
+  } catch (error) {
+    console.error('Update settings error:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -17,6 +17,7 @@ import attendanceRoutes from './routes/attendanceRoutes';
 import resourceRoutes from './routes/resourceRoutes';
 import eventRoutes from './routes/eventRoutes';
 import galleryRoutes from './routes/galleryRoutes';
+import settingsRoutes from './routes/settingsRoutes';
 
 // Load environment variables
 dotenv.config();
@@ -55,6 +56,7 @@ app.use('/api/attendance', attendanceRoutes);
 app.use('/api/resources', resourceRoutes);
 app.use('/api/events', eventRoutes);
 app.use('/api/gallery', galleryRoutes);
+app.use('/api/settings', settingsRoutes);
 
 // Health check endpoint
 app.get('/api/health', (req, res) => {

--- a/apps/server/src/models/settings.model.ts
+++ b/apps/server/src/models/settings.model.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface ISettings extends Document {
+  siteName: string;
+  siteDescription?: string;
+  defaultUserRole: 'Admin' | 'Teacher' | 'Parent';
+}
+
+const settingsSchema = new Schema<ISettings>({
+  siteName: { type: String, required: true },
+  siteDescription: { type: String },
+  defaultUserRole: {
+    type: String,
+    enum: ['Admin', 'Teacher', 'Parent'],
+    default: 'Parent'
+  }
+}, { timestamps: true });
+
+const Settings = model<ISettings>('Settings', settingsSchema);
+
+export default Settings;

--- a/apps/server/src/routes/settingsRoutes.ts
+++ b/apps/server/src/routes/settingsRoutes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { getSettings, updateSettings } from '../controllers/settingsController';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { checkRole } from '../middleware/roleMiddleware';
+
+const router = Router();
+
+router.get('/', authMiddleware, getSettings);
+router.put('/', authMiddleware, checkRole(['Admin']), updateSettings);
+
+export default router;


### PR DESCRIPTION
## Summary
- define Settings model and CRUD controller
- expose `/api/settings` routes
- fetch and update settings on the client
- add settings hook and form in AdminSettings
- define Settings type for client

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687f8af7a0c4832788cba538e922f466