### PR TITLE
Implement real-time announcements

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useAuth } from '@/hooks/useAuth';
+import { useSocket } from '@/hooks/useSocket';
+import { Toaster } from 'sonner';
 import Layout from '@/components/layout/Layout';
 import Login from '@/pages/Login';
 import Register from '@/pages/Register';
@@ -103,9 +105,12 @@ const AppRoutes: React.FC = () => {
 };
 
 const App: React.FC = () => {
+  useSocket();
+
   return (
     <QueryClientProvider client={queryClient}>
       <AppRoutes />
+      <Toaster richColors position="top-right" />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/apps/client/src/env.d.ts
+++ b/apps/client/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
+  readonly VITE_SOCKET_URL: string;
   // Add other environment variables here as needed
 }
 

--- a/apps/client/src/hooks/useSocket.ts
+++ b/apps/client/src/hooks/useSocket.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { socket } from '@/utils/socket';
+import { toast } from 'sonner';
+
+export const useSocket = () => {
+  useEffect(() => {
+    const handleAnnouncement = (event: any) => {
+      const title = event?.title ?? 'New announcement';
+      toast.info(title);
+    };
+
+    socket.on('new_announcement', handleAnnouncement);
+
+    return () => {
+      socket.off('new_announcement', handleAnnouncement);
+    };
+  }, []);
+};

--- a/apps/client/src/utils/socket.ts
+++ b/apps/client/src/utils/socket.ts
@@ -1,0 +1,7 @@
+import { io, Socket } from 'socket.io-client';
+
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:5000';
+
+export const socket: Socket = io(SOCKET_URL, {
+  autoConnect: true,
+});

--- a/apps/server/src/controllers/eventController.ts
+++ b/apps/server/src/controllers/eventController.ts
@@ -20,8 +20,8 @@ export const createEvent = async (req: AuthRequest, res: Response) => {
     const populatedEvent = await Event.findById(event._id)
       .populate('createdBy', 'name role');
 
-    // TODO: Emit socket event for real-time notifications
-    // io.emit('new_announcement', populatedEvent);
+    // Emit socket event for real-time notifications
+    global.io.emit('new_announcement', populatedEvent);
 
     res.status(201).json({ 
       message: 'Event created successfully', 


### PR DESCRIPTION
## Summary
- emit `new_announcement` after saving an event
- add socket helper and hook on the client
- show toasts for announcements
- provide socket URL environment type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f8afb50a0832781b1adc303ccceb8