### PR TITLE
Use _id in auth responses

### DIFF
--- a/apps/client/src/pages/admin/UserManagement.tsx
+++ b/apps/client/src/pages/admin/UserManagement.tsx
@@ -31,12 +31,8 @@ const UserManagement: React.FC = () => {
         console.log('Fetching users from /users endpoint...');
         const response = await apiClient.get<UsersResponse>('/users');
         console.log('Users API response:', response);
-        // Ensure all users have _id
-        const users = response.users.map(user => ({
-          ...user,
-          _id: (user as any)._id || (user as any).id // Handle both _id and id for backward compatibility
-        }));
-        return { users };
+        // Users already contain _id from the API
+        return { users: response.users };
       } catch (err) {
         console.error('Error in users query:', err);
         toast.error('Failed to load users');

--- a/apps/server/src/controllers/authController.ts
+++ b/apps/server/src/controllers/authController.ts
@@ -35,7 +35,7 @@ export const register = async (req: Request, res: Response) => {
       message: 'User registered successfully',
       token,
       user: {
-        id: user._id,
+        _id: user._id,
         name: user.name,
         email: user.email,
         role: user.role,
@@ -71,7 +71,7 @@ export const login = async (req: Request, res: Response) => {
       message: 'Login successful',
       token,
       user: {
-        id: user._id,
+        _id: user._id,
         name: user.name,
         email: user.email,
         role: user.role,
@@ -89,7 +89,7 @@ export const getMe = async (req: AuthRequest, res: Response) => {
     const user = await User.findById(req.user!._id).populate('children');
     res.json({
       user: {
-        id: user!._id,
+        _id: user!._id,
         name: user!.name,
         email: user!.email,
         role: user!.role,


### PR DESCRIPTION
## Summary
- ensure auth responses use `_id`
- clean up User Management's user mapping

## Testing
- `pnpm --filter server exec tsc --noEmit` *(fails: Cannot find module '@types/express-serve-static-core')*
- `pnpm --filter client run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687fae6e3aac8327add1251ad2427ac5