### PR TITLE
Add teacher availability and class archiving

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -23,6 +23,7 @@ import TeacherResources from '@/pages/teacher/TeacherResources';
 import GalleryUpload from '@/pages/teacher/GalleryUpload';
 import TeacherClasses from '@/pages/teacher/TeacherClasses';
 import AttendanceMarking from '@/pages/teacher/AttendanceMarking';
+import TeacherAvailability from '@/pages/teacher/TeacherAvailability';
 import { CreateEventPage } from '@/pages/teacher/CreateEventPage';
 import { EventsList } from '@/pages/teacher/EventsList';
 import Children from '@/pages/parent/Children';
@@ -87,6 +88,7 @@ const AppRoutes: React.FC = () => {
           <Route path="teacher/events" element={<EventsList />} />
           <Route path="teacher/events/new" element={<CreateEventPage />} />
           <Route path="teacher/resources" element={<TeacherResources />} />
+          <Route path="teacher/availability" element={<TeacherAvailability />} />
           <Route path="teacher/gallery" element={<GalleryUpload />} />
 
           {/* Parent routes */}

--- a/apps/client/src/components/ui/checkbox.tsx
+++ b/apps/client/src/components/ui/checkbox.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(({ children, ...props }, ref) => (
+  <label className="inline-flex items-center space-x-2">
+    <input type="checkbox" ref={ref} className="h-4 w-4" {...props} />
+    {children && <span>{children}</span>}
+  </label>
+));
+Checkbox.displayName = 'Checkbox';
+
+export default Checkbox;

--- a/apps/client/src/pages/admin/ClassManagement.tsx
+++ b/apps/client/src/pages/admin/ClassManagement.tsx
@@ -290,10 +290,11 @@ type ClassTableProps = {
   teachers: User[];
   onEdit: (cls: Class) => void;
   onDelete: (id: string) => void;
+  onArchive: (id: string) => void;
   isLoading: boolean;
 };
 
-const ClassTable: React.FC<ClassTableProps> = ({ classes, teachers, onEdit, onDelete, isLoading }) => {
+const ClassTable: React.FC<ClassTableProps> = ({ classes, teachers, onEdit, onDelete, onArchive, isLoading }) => {
   const getTeacherName = (teacher: string | Teacher | User | null | undefined) => {
     if (!teacher) return <span className="text-gray-500">Unassigned</span>;
     if (typeof teacher === 'object' && 'name' in teacher) return teacher.name;
@@ -341,6 +342,9 @@ const ClassTable: React.FC<ClassTableProps> = ({ classes, teachers, onEdit, onDe
                 <td className="px-4 py-3 text-right space-x-2 whitespace-nowrap">
                   <Button variant="outline" size="sm" onClick={() => onEdit(cls)}>
                     <Pencil className="h-4 w-4 mr-1" /> Edit
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => onArchive(cls._id)}>
+                    Archive
                   </Button>
                   <Button variant="destructive" size="sm" onClick={() => onDelete(cls._id)}>
                     Delete
@@ -407,6 +411,15 @@ const ClassManagement: React.FC = () => {
     },
   });
 
+  const { mutate: archiveClass, isPending: isArchiving } = useMutation({
+    mutationFn: (id: string) => apiClient.put(`/classes/${id}/archive`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['classes'] });
+      toast.success('Class archived');
+    },
+    onError: (error: Error) => toast.error(error.message || 'Failed to archive class.')
+  });
+
   const handleOpenCreate = () => setDialogState({ open: true, classData: null });
   const handleOpenEdit = (cls: Class) => setDialogState({ open: true, classData: cls });
   const handleDeleteRequest = (id: string) => setDeleteDialogState({ open: true, classId: id });
@@ -415,6 +428,7 @@ const ClassManagement: React.FC = () => {
       deleteClass(deleteDialogState.classId);
     }
   };
+  const handleArchive = (id: string) => archiveClass(id);
 
   if (isError) {
     return <div className="p-4 text-red-500 bg-red-50 rounded-md">Error loading classes: {error.message}</div>;
@@ -453,6 +467,7 @@ const ClassManagement: React.FC = () => {
             teachers={teachers}
             onEdit={handleOpenEdit}
             onDelete={handleDeleteRequest}
+            onArchive={handleArchive}
             isLoading={isLoading}
           />
         </CardContent>

--- a/apps/client/src/pages/teacher/TeacherAvailability.tsx
+++ b/apps/client/src/pages/teacher/TeacherAvailability.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/utils/api';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+
+const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+
+export const TeacherAvailability: React.FC = () => {
+  const { register, handleSubmit, setValue } = useForm<{availability: string[]}>();
+
+  const { data } = useQuery<{ user: { availability: string[] } }>({
+    queryKey: ['me','availability'],
+    queryFn: () => apiClient.get('/users/me'),
+  });
+
+  useEffect(() => {
+    if(data?.user?.availability){
+      setValue('availability', data.user.availability);
+    }
+  }, [data, setValue]);
+
+  const mutation = useMutation({
+    mutationFn: (values: {availability: string[]}) => apiClient.put('/users/me/availability', values),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>My Availability</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(v => mutation.mutate(v))} className="space-y-2">
+          {days.map(day => (
+            <label key={day} className="flex items-center space-x-2">
+              <Checkbox value={day} {...register('availability')} />
+              <span>{day}</span>
+            </label>
+          ))}
+          <Button type="submit" disabled={mutation.isPending}>Save</Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TeacherAvailability;

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -5,6 +5,7 @@ export interface User {
   role: 'Admin' | 'Teacher' | 'Parent';
   password?: string;
   profilePictureUrl: string;
+  availability?: string[];
   children?: string[] | Child[];
   createdAt: string;
   updatedAt: string;
@@ -42,6 +43,7 @@ export interface Class {
   capacity: number;
   description?: string;
   teacher?: string | User;
+  archived?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -57,6 +59,7 @@ export interface Schedule {
   className?: string; // For display purposes when populated
   teacher: string | User;
   students: string[] | Child[];
+  room?: string;
   status: 'Scheduled' | 'Completed' | 'Cancelled';
   createdAt: string;
   updatedAt: string;

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
+    "csv-parse": "^6.1.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
@@ -33,4 +34,3 @@
     "typescript": "^5.5.3"
   }
 }
-

--- a/apps/server/src/controllers/classController.ts
+++ b/apps/server/src/controllers/classController.ts
@@ -73,6 +73,23 @@ export const updateClass = async (req: AuthRequest, res: Response) => {
   }
 };
 
+export const archiveClass = async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const cls = await Class.findByIdAndUpdate(id, { archived: true }, { new: true });
+
+    if (!cls) {
+      return res.status(404).json({ message: 'Class not found' });
+    }
+
+    res.json({ message: 'Class archived', class: cls });
+  } catch (error) {
+    console.error('Archive class error:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
 export const deleteClass = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;

--- a/apps/server/src/controllers/scheduleController.ts
+++ b/apps/server/src/controllers/scheduleController.ts
@@ -5,7 +5,7 @@ import { AuthRequest } from '../middleware/authMiddleware';
 
 export const createSchedule = async (req: AuthRequest, res: Response) => {
   try {
-    const { classId, teacherId, date } = req.body;
+    const { classId, teacherId, date, room } = req.body;
 
     // Get all students assigned to this class
     const students = await Child.find({ assignedClass: classId });
@@ -15,7 +15,8 @@ export const createSchedule = async (req: AuthRequest, res: Response) => {
       class: classId,
       teacher: teacherId,
       students: studentIds,
-      date: new Date(date)
+      date: new Date(date),
+      room
     });
 
     await schedule.save();

--- a/apps/server/src/controllers/userController.ts
+++ b/apps/server/src/controllers/userController.ts
@@ -1,4 +1,7 @@
 import { Response } from 'express';
+import bcrypt from 'bcryptjs';
+import fs from 'fs';
+import { parse } from 'csv-parse/sync';
 import User from '../models/user.model';
 import { AuthRequest } from '../middleware/authMiddleware';
 
@@ -103,10 +106,126 @@ export const getTeachers = async (req: AuthRequest, res: Response) => {
     const teachers = await User.find({ role: 'Teacher' })
       .select('-password -__v -createdAt -updatedAt')
       .lean();
-    
+
     res.json({ users: teachers });
   } catch (error) {
     console.error('Get teachers error:', error);
     res.status(500).json({ success: false, message: 'Error fetching teachers' });
+  }
+};
+
+export const createUser = async (req: AuthRequest, res: Response) => {
+  try {
+    const { name, email, password, role, profilePictureUrl, availability } = req.body;
+
+    if (!name || !email || !password) {
+      return res.status(400).json({ message: 'Name, email and password are required' });
+    }
+
+    if (role && !['Admin', 'Teacher', 'Parent'].includes(role)) {
+      return res.status(400).json({ message: 'Invalid role' });
+    }
+
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({
+      name,
+      email,
+      password: hashed,
+      role: role || 'Parent',
+      profilePictureUrl,
+      availability
+    });
+
+    const userObj = user.toObject();
+    delete userObj.password;
+
+    res.status(201).json({ message: 'User created', user: userObj });
+  } catch (error) {
+    console.error('Create user error:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const bulkCreateUsers = async (req: AuthRequest, res: Response) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: 'CSV file is required' });
+    }
+
+    const fileContent = fs.readFileSync(req.file.path);
+    const records = parse(fileContent, { columns: true, skip_empty_lines: true });
+
+    const created: any[] = [];
+    const errors: Array<{ row: number; message: string }> = [];
+
+    for (const [index, record] of records.entries()) {
+      const { name, email, password, role, profilePictureUrl, availability } = record;
+
+      if (!name || !email || !password) {
+        errors.push({ row: index + 1, message: 'Missing required fields' });
+        continue;
+      }
+
+      if (role && !['Admin', 'Teacher', 'Parent'].includes(role)) {
+        errors.push({ row: index + 1, message: 'Invalid role' });
+        continue;
+      }
+
+      const exists = await User.findOne({ email });
+      if (exists) {
+        errors.push({ row: index + 1, message: 'User already exists' });
+        continue;
+      }
+
+      const hashed = await bcrypt.hash(password, 10);
+      const user = await User.create({
+        name,
+        email,
+        password: hashed,
+        role: role || 'Parent',
+        profilePictureUrl,
+        availability
+      });
+
+      created.push({ _id: user._id, name: user.name, email: user.email, role: user.role });
+    }
+
+    fs.unlink(req.file.path, () => undefined);
+
+    res.json({ message: 'Bulk upload complete', created, errors });
+  } catch (error) {
+    console.error('Bulk create users error:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const updateMyAvailability = async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?._id;
+    const { availability } = req.body;
+
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const user = await User.findByIdAndUpdate(
+      userId,
+      { availability },
+      { new: true }
+    ).select('-password');
+
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    res.json({ message: 'Availability updated', user });
+  } catch (error) {
+    console.error('Update availability error:', error);
+    res.status(500).json({ message: 'Server error' });
   }
 };

--- a/apps/server/src/models/class.model.ts
+++ b/apps/server/src/models/class.model.ts
@@ -7,6 +7,7 @@ export interface IClass extends Document {
   description?: string;
   teacher: Schema.Types.ObjectId;
   students: Schema.Types.ObjectId[];
+  archived: boolean;
 }
 
 const classSchema = new Schema<IClass>({
@@ -14,15 +15,16 @@ const classSchema = new Schema<IClass>({
   ageRange: { type: String, required: true },
   capacity: { type: Number, required: true },
   description: { type: String },
-  teacher: { 
-    type: Schema.Types.ObjectId, 
+  teacher: {
+    type: Schema.Types.ObjectId,
     ref: 'User',
-    required: true 
+    required: true
   },
   students: [{
     type: Schema.Types.ObjectId,
     ref: 'Child'
-  }]
+  }],
+  archived: { type: Boolean, default: false }
 }, { timestamps: true });
 
 const Class = model<IClass>('Class', classSchema);

--- a/apps/server/src/models/schedule.model.ts
+++ b/apps/server/src/models/schedule.model.ts
@@ -5,6 +5,7 @@ export interface ISchedule extends Document {
   teacher: Schema.Types.ObjectId;
   students: Schema.Types.ObjectId[];
   date: Date;
+  room?: string;
 }
 
 const scheduleSchema = new Schema<ISchedule>({
@@ -12,6 +13,7 @@ const scheduleSchema = new Schema<ISchedule>({
   teacher: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   students: [{ type: Schema.Types.ObjectId, ref: 'Child' }],
   date: { type: Date, required: true },
+  room: { type: String },
 }, { timestamps: true });
 
 const Schedule = model<ISchedule>('Schedule', scheduleSchema);

--- a/apps/server/src/models/user.model.ts
+++ b/apps/server/src/models/user.model.ts
@@ -7,6 +7,7 @@ export interface IUser extends Document {
   role: 'Admin' | 'Teacher' | 'Parent';
   children?: Schema.Types.ObjectId[];
   profilePictureUrl: string;
+  availability: string[];
 }
 
 const userSchema = new Schema<IUser>({
@@ -16,6 +17,7 @@ const userSchema = new Schema<IUser>({
   role: { type: String, enum: ['Admin', 'Teacher', 'Parent'], default: 'Parent' },
   children: [{ type: Schema.Types.ObjectId, ref: 'Child' }],
   profilePictureUrl: { type: String, default: 'default-avatar-url' },
+  availability: { type: [String], default: [] },
 }, { timestamps: true });
 
 const User = model<IUser>('User', userSchema);

--- a/apps/server/src/routes/classRoutes.ts
+++ b/apps/server/src/routes/classRoutes.ts
@@ -3,8 +3,9 @@ import {
   createClass, 
   getAllClasses, 
   getClassById, 
-  updateClass, 
-  deleteClass, 
+  updateClass,
+  archiveClass,
+  deleteClass,
   assignStudentToClass,
   getTeacherClasses
 } from '../controllers/classController';
@@ -16,6 +17,7 @@ const router: import("express").Router = Router();
 // Admin only routes
 router.post('/', authMiddleware, checkRole(['Admin']), createClass);
 router.put('/:id', authMiddleware, checkRole(['Admin']), updateClass);
+router.put('/:id/archive', authMiddleware, checkRole(['Admin']), archiveClass);
 router.delete('/:id', authMiddleware, checkRole(['Admin']), deleteClass);
 router.post('/:id/assign-student', authMiddleware, checkRole(['Admin']), assignStudentToClass);
 

--- a/apps/server/src/routes/userRoutes.ts
+++ b/apps/server/src/routes/userRoutes.ts
@@ -1,15 +1,22 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { getAllUsers, updateUserRole, deleteUser, getTeachers } from '../controllers/userController';
+import multer from 'multer';
+import { getAllUsers, updateUserRole, deleteUser, getTeachers, createUser, bulkCreateUsers, updateMyAvailability } from '../controllers/userController';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { checkRole } from '../middleware/roleMiddleware';
 
 const router: import("express").Router = Router();
+const upload = multer({ dest: 'uploads' });
 
 // Admin only routes
 router.get('/', authMiddleware, checkRole(['Admin']), getAllUsers);
 router.get('/teachers', authMiddleware, getTeachers);
+router.post('/', authMiddleware, checkRole(['Admin']), createUser);
+router.post('/bulk', authMiddleware, checkRole(['Admin']), upload.single('file'), bulkCreateUsers);
 router.put('/:id/role', authMiddleware, checkRole(['Admin']), updateUserRole);
 router.delete('/:id', authMiddleware, checkRole(['Admin']), deleteUser);
+
+// Teacher profile
+router.put('/me/availability', authMiddleware, checkRole(['Teacher']), updateMyAvailability);
 
 export default router;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      csv-parse:
+        specifier: ^6.1.0
+        version: 6.1.0
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -1546,6 +1549,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csv-parse@6.1.0:
+    resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -4615,6 +4621,8 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
+
+  csv-parse@6.1.0: {}
 
   data-urls@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- extend user, class, and schedule models with availability, archived, and room fields
- allow admins to set profile picture on user creation
- expose endpoint for teachers to update availability
- support class archiving via new route
- add teacher availability form page
- include simple checkbox UI component

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687fb4c128508327a74ab98b1c972593