### PR TITLE
Add analytics and cloud-based features

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,13 +13,18 @@
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cloudinary": "^2.7.0",
     "cors": "^2.8.5",
     "csv-parse": "^6.1.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "json2csv": "6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.4.4",
     "multer": "^1.4.5-lts.1",
+    "multer-storage-cloudinary": "^4.0.0",
+    "node-cron": "^4.2.1",
+    "pdfkit": "^0.17.1",
     "socket.io": "^4.7.5"
   },
   "devDependencies": {

--- a/apps/server/src/controllers/analyticsController.ts
+++ b/apps/server/src/controllers/analyticsController.ts
@@ -1,0 +1,60 @@
+import { Response } from 'express';
+import Attendance from '../models/attendance.model';
+import Class from '../models/class.model';
+import Schedule from '../models/schedule.model';
+import { AuthRequest } from '../middleware/authMiddleware';
+import User from '../models/user.model';
+
+export const attendanceTrends = async (req: AuthRequest, res: Response) => {
+  const { timeframe = 'weekly', classId } = req.query;
+  const now = new Date();
+  const days = timeframe === 'monthly' ? 30 : 7;
+  const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+  const match: any = { 'schedule.date': { $gte: start, $lte: now } };
+  if (classId) match['schedule.class'] = classId;
+
+  const data = await Attendance.aggregate([
+    { $lookup: { from: 'schedules', localField: 'schedule', foreignField: '_id', as: 'schedule' } },
+    { $unwind: '$schedule' },
+    { $match: match },
+    { $group: {
+        _id: { $dateToString: { format: '%Y-%m-%d', date: '$schedule.date' } },
+        total: { $sum: 1 },
+        present: { $sum: { $cond: [{ $eq: ['$status', 'Present'] }, 1, 0] } }
+    }},
+    { $project: { _id: 0, date: '$_id', percentage: { $multiply: [{ $cond: [{ $eq: ['$total', 0] }, 0, { $divide: ['$present', '$total'] }] }, 100] } } },
+    { $sort: { date: 1 } }
+  ]);
+
+  res.json({ data });
+};
+
+export const classCapacity = async (req: AuthRequest, res: Response) => {
+  const classes = await Class.find().select('name capacity students');
+  const data = classes.map(c => ({
+    _id: c._id,
+    name: c.name,
+    capacity: c.capacity,
+    currentEnrollment: c.students.length
+  }));
+  res.json({ data });
+};
+
+export const teacherWorkload = async (req: AuthRequest, res: Response) => {
+  const { timeframe = 'monthly' } = req.query;
+  const now = new Date();
+  const days = timeframe === 'weekly' ? 7 : 30;
+  const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+  const data = await Schedule.aggregate([
+    { $match: { date: { $gte: start, $lte: now } } },
+    { $group: { _id: '$teacher', count: { $sum: 1 } } },
+    { $lookup: { from: 'users', localField: '_id', foreignField: '_id', as: 'teacher' } },
+    { $unwind: '$teacher' },
+    { $project: { _id: 0, teacher: '$teacher.name', classes: '$count' } }
+  ]);
+
+  res.json({ data });
+};
+

--- a/apps/server/src/controllers/eventController.ts
+++ b/apps/server/src/controllers/eventController.ts
@@ -12,7 +12,8 @@ export const createEvent = async (req: AuthRequest, res: Response) => {
       type,
       description,
       date: new Date(date),
-      createdBy
+      createdBy,
+      status: 'Sent'
     });
 
     await event.save();
@@ -29,6 +30,36 @@ export const createEvent = async (req: AuthRequest, res: Response) => {
     });
   } catch (error) {
     console.error('Create event error:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const scheduleEvent = async (req: AuthRequest, res: Response) => {
+  try {
+    const { title, type, description, date, scheduledFor } = req.body;
+    const createdBy = req.user!._id;
+
+    const event = new Event({
+      title,
+      type,
+      description,
+      date: new Date(date),
+      scheduledFor: new Date(scheduledFor),
+      createdBy,
+      status: 'Scheduled'
+    });
+
+    await event.save();
+
+    const populatedEvent = await Event.findById(event._id)
+      .populate('createdBy', 'name role');
+
+    res.status(201).json({
+      message: 'Event scheduled successfully',
+      event: populatedEvent
+    });
+  } catch (error) {
+    console.error('Schedule event error:', error);
     res.status(500).json({ message: 'Server error' });
   }
 };

--- a/apps/server/src/controllers/galleryController.ts
+++ b/apps/server/src/controllers/galleryController.ts
@@ -11,12 +11,11 @@ export const uploadGalleryImage = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'No image uploaded' });
     }
 
-    // In a real application, you would upload to cloud storage (Cloudinary, AWS S3, etc.)
-    // For now, we'll use the local file path
-    const imageUrl = `/uploads/${req.file.filename}`;
+    const { path: secure_url, filename: public_id } = req.file as any;
 
     const galleryImage = new GalleryImage({
-      imageUrl,
+      secure_url,
+      public_id,
       caption,
       event: eventId || undefined,
       class: classId || undefined,

--- a/apps/server/src/controllers/reportsController.ts
+++ b/apps/server/src/controllers/reportsController.ts
@@ -1,0 +1,34 @@
+import { Response } from 'express';
+import { Parser } from 'json2csv';
+import PDFDocument from 'pdfkit';
+import Attendance from '../models/attendance.model';
+import { AuthRequest } from '../middleware/authMiddleware';
+
+export const generateReport = async (req: AuthRequest, res: Response) => {
+  const { reportType, format, options } = req.body;
+
+  if (reportType !== 'attendance') {
+    return res.status(400).json({ message: 'Unsupported report type' });
+  }
+
+  const records = await Attendance.find({}).populate({
+    path: 'schedule',
+    populate: { path: 'class', select: 'name' }
+  }).lean();
+
+  if (format === 'csv') {
+    const parser = new Parser();
+    const csv = parser.parse(records);
+    res.setHeader('Content-Type', 'text/csv');
+    return res.send(csv);
+  } else {
+    const doc = new PDFDocument();
+    res.setHeader('Content-Type', 'application/pdf');
+    doc.pipe(res);
+    records.forEach(r => {
+      const cls = (r.schedule as any).class;
+      doc.text(`${cls?.name || ''} - ${r.status}`);
+    });
+    doc.end();
+  }
+};

--- a/apps/server/src/controllers/user.controller.ts
+++ b/apps/server/src/controllers/user.controller.ts
@@ -458,3 +458,23 @@ export const updateMyAvailability = async (req: AuthRequest, res: Response, next
     next(error);
   }
 };
+
+export const registerPushToken = async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { token } = req.body;
+    if (!token) {
+      throw new BadRequestError('Token is required');
+    }
+    const user = await User.findByIdAndUpdate(
+      req.user?._id,
+      { $addToSet: { pushTokens: token } },
+      { new: true }
+    );
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -18,7 +18,10 @@ import resourceRoutes from './routes/resourceRoutes';
 import eventRoutes from './routes/eventRoutes';
 import galleryRoutes from './routes/galleryRoutes';
 import settingsRoutes from './routes/settingsRoutes';
+import analyticsRoutes from './routes/analyticsRoutes';
+import reportRoutes from './routes/reportRoutes';
 import { errorHandler } from './utils/errors';
+import { startAnnouncementJob } from './jobs/announcementJob';
 
 // Load environment variables
 dotenv.config();
@@ -74,6 +77,8 @@ app.use('/api/resources', resourceRoutes);
 app.use('/api/events', eventRoutes);
 app.use('/api/gallery', galleryRoutes);
 app.use('/api/settings', settingsRoutes);
+app.use('/api/reports', reportRoutes);
+app.use('/api/analytics', analyticsRoutes);
 
 // Health check endpoint
 app.get('/api/health', (req, res) => {
@@ -129,6 +134,7 @@ const startServer = async () => {
 📚 API Documentation: http://localhost:${PORT}/api-docs
 ================================================
 `);
+      startAnnouncementJob();
     });
 
     // Handle unhandled promise rejections

--- a/apps/server/src/jobs/announcementJob.ts
+++ b/apps/server/src/jobs/announcementJob.ts
@@ -1,0 +1,18 @@
+import cron from 'node-cron';
+import Event from '../models/event.model';
+
+export const startAnnouncementJob = () => {
+  cron.schedule('* * * * *', async () => {
+    const dueEvents = await Event.find({
+      status: 'Scheduled',
+      scheduledFor: { $lte: new Date() }
+    });
+
+    for (const event of dueEvents) {
+      event.status = 'Sent';
+      await event.save();
+      const populated = await Event.findById(event._id).populate('createdBy', 'name role');
+      global.io.emit('new_announcement', populated);
+    }
+  });
+};

--- a/apps/server/src/middleware/cloudinaryUpload.ts
+++ b/apps/server/src/middleware/cloudinaryUpload.ts
@@ -1,0 +1,10 @@
+import { CloudinaryStorage } from 'multer-storage-cloudinary';
+import multer from 'multer';
+import cloudinary from '../utils/cloudinary';
+
+const storage = new CloudinaryStorage({
+  cloudinary,
+  params: { folder: 'gallery' } as any
+});
+
+export const cloudinaryUpload = multer({ storage });

--- a/apps/server/src/models/event.model.ts
+++ b/apps/server/src/models/event.model.ts
@@ -6,6 +6,8 @@ export interface IEvent extends Document {
   description?: string;
   date: Date;
   createdBy: Schema.Types.ObjectId;
+  scheduledFor?: Date;
+  status: 'Draft' | 'Scheduled' | 'Sent';
 }
 
 const eventSchema = new Schema<IEvent>({
@@ -14,6 +16,8 @@ const eventSchema = new Schema<IEvent>({
   description: { type: String },
   date: { type: Date, required: true },
   createdBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  scheduledFor: { type: Date, index: true },
+  status: { type: String, enum: ['Draft', 'Scheduled', 'Sent'], default: 'Draft' },
 }, { timestamps: true });
 
 const Event = model<IEvent>('Event', eventSchema);

--- a/apps/server/src/models/galleryImage.model.ts
+++ b/apps/server/src/models/galleryImage.model.ts
@@ -1,7 +1,8 @@
 import { Schema, model, Document } from 'mongoose';
 
 export interface IGalleryImage extends Document {
-  imageUrl: string;
+  secure_url: string;
+  public_id: string;
   caption?: string;
   event?: Schema.Types.ObjectId;
   class?: Schema.Types.ObjectId;
@@ -10,7 +11,8 @@ export interface IGalleryImage extends Document {
 }
 
 const galleryImageSchema = new Schema<IGalleryImage>({
-  imageUrl: { type: String, required: true },
+  secure_url: { type: String, required: true },
+  public_id: { type: String, required: true },
   caption: { type: String },
   event: { type: Schema.Types.ObjectId, ref: 'Event' },
   class: { type: Schema.Types.ObjectId, ref: 'Class' },

--- a/apps/server/src/models/user.model.ts
+++ b/apps/server/src/models/user.model.ts
@@ -13,6 +13,7 @@ export interface IUser extends Document {
   phoneNumber?: string;
   address?: string;
   dateOfBirth?: Date;
+  pushTokens: string[];
   createdAt: Date;
   updatedAt: Date;
   __v?: number;
@@ -66,9 +67,10 @@ const userSchema = new Schema<IUser>({
   dateOfBirth: {
     type: Date
   },
-  availability: { 
-    type: [String], 
-    default: [] 
+  pushTokens: [{ type: String }],
+  availability: {
+    type: [String],
+    default: []
   },
 }, { 
   timestamps: true,

--- a/apps/server/src/routes/analyticsRoutes.ts
+++ b/apps/server/src/routes/analyticsRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { checkRole } from '../middleware/roleMiddleware';
+import { attendanceTrends, classCapacity, teacherWorkload } from '../controllers/analyticsController';
+
+const router: Router = Router();
+
+router.use(authMiddleware);
+router.get('/attendance-trends', checkRole(['Admin', 'Teacher']), attendanceTrends);
+router.get('/class-capacity', checkRole(['Admin']), classCapacity);
+router.get('/teacher-workload', checkRole(['Admin']), teacherWorkload);
+
+export default router;

--- a/apps/server/src/routes/eventRoutes.ts
+++ b/apps/server/src/routes/eventRoutes.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { createEvent, getAllEvents, updateEvent, deleteEvent } from '../controllers/eventController';
+import { createEvent, scheduleEvent, getAllEvents, updateEvent, deleteEvent } from '../controllers/eventController';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { checkRole } from '../middleware/roleMiddleware';
 
@@ -7,6 +7,7 @@ const router: import("express").Router = Router();
 
 // Admin/Teacher routes
 router.post('/', authMiddleware, checkRole(['Admin', 'Teacher']), createEvent);
+router.post('/schedule', authMiddleware, checkRole(['Admin', 'Teacher']), scheduleEvent);
 router.put('/:id', authMiddleware, checkRole(['Admin', 'Teacher']), updateEvent);
 router.delete('/:id', authMiddleware, checkRole(['Admin']), deleteEvent);
 

--- a/apps/server/src/routes/galleryRoutes.ts
+++ b/apps/server/src/routes/galleryRoutes.ts
@@ -1,6 +1,5 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import multer from 'multer';
-import path from 'path';
+import { cloudinaryUpload } from '../middleware/cloudinaryUpload';
 import { 
   uploadGalleryImage, 
   getApprovedImages, 
@@ -12,35 +11,9 @@ import { checkRole } from '../middleware/roleMiddleware';
 
 const router: import("express").Router = Router();
 
-// Configure multer for image uploads
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, 'uploads/gallery/');
-  },
-  filename: (req, file, cb) => {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
-    cb(null, file.fieldname + '-' + uniqueSuffix + path.extname(file.originalname));
-  }
-});
-
-const upload = multer({ 
-  storage,
-  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB limit
-  fileFilter: (req, file, cb) => {
-    const allowedTypes = /jpg|jpeg|png|gif/;
-    const extname = allowedTypes.test(path.extname(file.originalname).toLowerCase());
-    const mimetype = allowedTypes.test(file.mimetype);
-    
-    if (mimetype && extname) {
-      return cb(null, true);
-    } else {
-      cb(new Error('Only image files are allowed'));
-    }
-  }
-});
 
 // Teacher routes
-router.post('/upload', authMiddleware, checkRole(['Teacher']), upload.single('image'), uploadGalleryImage);
+router.post('/upload', authMiddleware, checkRole(['Teacher']), cloudinaryUpload.single('image'), uploadGalleryImage);
 
 // Authenticated routes
 router.get('/', authMiddleware, getApprovedImages);

--- a/apps/server/src/routes/reportRoutes.ts
+++ b/apps/server/src/routes/reportRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { checkRole } from '../middleware/roleMiddleware';
+import { generateReport } from '../controllers/reportsController';
+
+const router: Router = Router();
+router.post('/generate', authMiddleware, checkRole(['Admin']), generateReport);
+export default router;

--- a/apps/server/src/routes/user.routes.ts
+++ b/apps/server/src/routes/user.routes.ts
@@ -17,6 +17,7 @@ router.use(authMiddleware);
 router.get('/me', userController.getCurrentUser);
 router.put('/me/profile', userController.updateUserProfile);
 router.post('/me/availability', userController.updateMyAvailability);
+router.post('/me/push-token', userController.registerPushToken);
 
 // Profile picture upload route with proper middleware typing
 const [uploadMiddleware, uploadHandler] = userController.uploadProfilePictureHandler;

--- a/apps/server/src/types.d.ts
+++ b/apps/server/src/types.d.ts
@@ -1,0 +1,2 @@
+declare module 'json2csv';
+declare module 'pdfkit';

--- a/apps/server/src/utils/cloudinary.ts
+++ b/apps/server/src/utils/cloudinary.ts
@@ -1,0 +1,9 @@
+import { v2 as cloudinary } from 'cloudinary';
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+});
+
+export default cloudinary;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
+      cloudinary:
+        specifier: ^2.7.0
+        version: 2.7.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -178,6 +181,9 @@ importers:
       express:
         specifier: ^4.19.2
         version: 4.21.2
+      json2csv:
+        specifier: 6.0.0-alpha.2
+        version: 6.0.0-alpha.2
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -187,6 +193,15 @@ importers:
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.2
+      multer-storage-cloudinary:
+        specifier: ^4.0.0
+        version: 4.0.0(cloudinary@2.7.0)
+      node-cron:
+        specifier: ^4.2.1
+        version: 4.2.1
+      pdfkit:
+        specifier: ^0.17.1
+        version: 0.17.1
       socket.io:
         specifier: ^4.7.5
         version: 4.8.1
@@ -1064,6 +1079,12 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@streamparser/json@0.0.6':
+    resolution: {integrity: sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==}
+
+  '@swc/helpers@0.5.17':
+    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+
   '@tanstack/query-core@5.83.0':
     resolution: {integrity: sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==}
 
@@ -1389,6 +1410,13 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   base64id@2.0.0:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
@@ -1413,6 +1441,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
 
   browserslist@4.25.1:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
@@ -1486,6 +1517,14 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
+  cloudinary@2.7.0:
+    resolution: {integrity: sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==}
+    engines: {node: '>=9'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1499,6 +1538,10 @@ packages:
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
   concat-map@0.0.1:
@@ -1546,6 +1589,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -1633,6 +1679,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1840,6 +1889,9 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -2128,6 +2180,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jpeg-exif@1.1.4:
+    resolution: {integrity: sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2161,6 +2216,11 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json2csv@6.0.0-alpha.2:
+    resolution: {integrity: sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==}
+    engines: {node: '>= 12', npm: '>= 6.13.0'}
+    hasBin: true
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2191,6 +2251,9 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2201,6 +2264,10 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -2376,6 +2443,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multer-storage-cloudinary@4.0.0:
+    resolution: {integrity: sha512-25lm9R6o5dWrHLqLvygNX+kBOxprzpmZdnVKH4+r68WcfCt8XV6xfQaMuAg+kUE5Xmr8mJNA4gE0AcBj9FJyWA==}
+    peerDependencies:
+      cloudinary: ^1.21.0
+
   multer@1.4.5-lts.2:
     resolution: {integrity: sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==}
     engines: {node: '>= 6.0.0'}
@@ -2395,6 +2467,10 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  node-cron@4.2.1:
+    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
+    engines: {node: '>=6.0.0'}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -2473,6 +2549,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2523,6 +2602,9 @@ packages:
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
+  pdfkit@0.17.1:
+    resolution: {integrity: sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2540,6 +2622,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  png-js@1.0.0:
+    resolution: {integrity: sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2611,6 +2696,14 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  q@1.5.1:
+    resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
+    engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -2727,6 +2820,9 @@ packages:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2961,6 +3057,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3057,6 +3156,12 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -4069,6 +4174,12 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@streamparser/json@0.0.6': {}
+
+  '@swc/helpers@0.5.17':
+    dependencies:
+      tslib: 2.8.1
+
   '@tanstack/query-core@5.83.0': {}
 
   '@tanstack/query-devtools@5.81.2': {}
@@ -4459,6 +4570,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
   base64id@2.0.0: {}
 
   bcryptjs@2.4.3: {}
@@ -4494,6 +4609,10 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
 
   browserslist@4.25.1:
     dependencies:
@@ -4579,6 +4698,13 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  clone@2.1.2: {}
+
+  cloudinary@2.7.0:
+    dependencies:
+      lodash: 4.17.21
+      q: 1.5.1
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -4588,6 +4714,8 @@ snapshots:
   color-name@1.1.4: {}
 
   commander@4.1.1: {}
+
+  commander@6.2.1: {}
 
   concat-map@0.0.1: {}
 
@@ -4628,6 +4756,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-js@4.2.0: {}
 
   css.escape@1.5.1: {}
 
@@ -4711,6 +4841,8 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-node-es@1.1.0: {}
+
+  dfa@1.2.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -5023,6 +5155,18 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.17
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -5303,6 +5447,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jpeg-exif@1.1.4: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -5346,6 +5492,12 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json2csv@6.0.0-alpha.2:
+    dependencies:
+      '@streamparser/json': 0.0.6
+      commander: 6.2.1
+      lodash.get: 4.4.2
+
   json5@2.2.3: {}
 
   jsonwebtoken@9.0.2:
@@ -5385,6 +5537,11 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   lines-and-columns@1.2.4: {}
 
   local-pkg@0.5.1:
@@ -5395,6 +5552,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.get@4.4.2: {}
 
   lodash.includes@4.3.0: {}
 
@@ -5536,6 +5695,10 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multer-storage-cloudinary@4.0.0(cloudinary@2.7.0):
+    dependencies:
+      cloudinary: 2.7.0
+
   multer@1.4.5-lts.2:
     dependencies:
       append-field: 1.0.0
@@ -5557,6 +5720,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  node-cron@4.2.1: {}
 
   node-releases@2.0.19: {}
 
@@ -5640,6 +5805,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@0.2.9: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5675,6 +5842,14 @@ snapshots:
 
   pathval@1.1.1: {}
 
+  pdfkit@0.17.1:
+    dependencies:
+      crypto-js: 4.2.0
+      fontkit: 2.0.4
+      jpeg-exif: 1.1.4
+      linebreak: 1.1.0
+      png-js: 1.0.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -5688,6 +5863,8 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.4
       pathe: 2.0.3
+
+  png-js@1.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -5753,6 +5930,8 @@ snapshots:
   pstree.remy@1.1.8: {}
 
   punycode@2.3.1: {}
+
+  q@1.5.1: {}
 
   qs@6.13.0:
     dependencies:
@@ -5874,6 +6053,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restructure@3.0.2: {}
 
   reusify@1.1.0: {}
 
@@ -6194,6 +6375,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-inflate@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinypool@0.8.4: {}
@@ -6270,6 +6453,16 @@ snapshots:
   undefsafe@2.0.5: {}
 
   undici-types@6.21.0: {}
+
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- extend Event schema with scheduled sending
- create cron job to send scheduled announcements
- integrate Cloudinary uploads for gallery images
- add analytics endpoints and report generation
- enable push token registration for mobile clients

## Testing
- `pnpm exec vitest run`
- `tsc -p apps/server/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68838c504660832799f2fba9d2481dd7