### PR TITLE
Fix infinite re-fetch loop

### DIFF
--- a/apps/client/src/pages/admin/Scheduling.tsx
+++ b/apps/client/src/pages/admin/Scheduling.tsx
@@ -315,7 +315,7 @@ const Scheduling: React.FC = () => {
 
   // Fetch Teachers
   const { data: teachersResponse, isLoading: isLoadingTeachers } = useQuery<{ users: User[] }>({
-    queryKey: ['users', { role: 'Teacher' }], // More specific query key
+    queryKey: ['teachers'], // Stable query key avoids re-fetching on each render
     queryFn: () => apiClient.get('/users/teachers'),
   });
 


### PR DESCRIPTION
## Summary
- keep `useQuery` key for teachers stable to avoid repeated fetches

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839ca63950832797878361263e673e